### PR TITLE
Set 'restart_policy: always' on prometheus docker containers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
     - 9093:9093
     #read_only: True
     recreate: "{{ prometheus_alertmanager_configuration.changed }}"
-    restart_policy: on-failure
+    restart_policy: always
     state: started
     volumes:
     - /etc/prometheus/alertmanager.yml:/etc/prometheus/alertmanager.yml:ro
@@ -97,7 +97,7 @@
     - 9115:9115
     #read_only: True
     recreate: "{{ prometheus_blackboxexporter_configuration.changed }}"
-    restart_policy: on-failure
+    restart_policy: always
     state: started
     volumes:
     - /etc/prometheus/blackbox-exporter.yml:/etc/prometheus/blackbox-exporter.yml:ro
@@ -120,7 +120,7 @@
     - 9090:9090
     #read_only: True
     recreate: "{{ prometheus_configuration.changed or prometheus_alert_rules.changed }}"
-    restart_policy: on-failure
+    restart_policy: always
     state: started
     volumes:
     # We could mount /etc/prometheus instead but the Docker image contains


### PR DESCRIPTION
The previous `restart_policy: on-failure` doesn't start the container following a reboot.

This PR changes it to `always`. We could also consider `unless-stopped`, and/or limiting the number of `restart_retries`: https://docs.ansible.com/ansible/docker_container_module.html

Tag: `0.1.1`