### PR TITLE
Move prometheus_targets into main targets (IDR-0.4.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,7 @@ services:
   - docker
 
 install:
-  # Ansible 2.2 has a bug that causes task prometheus | docker alertmanager
-  # to fail when evaluating
-  # prometheus_alertmanager_configuration.changed
-  # https://github.com/ansible/ansible/issues/20568
-  #- pip install ome-ansible-molecule-dependencies
-  - pip install ansible==2.3.1.0 docker molecule==1.24
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ This role is still in development.
 Parameters
 ----------
 
-- `prometheus_targets`: Optional list of dictionaries of additional targets:
+- `prometheus_targets`: Optional list of dictionaries of targets:
+  - `group`: A list of Ansible groups (optional)
+  - `hosts`: A list of hosts (optional)
+  - `port`: The port to be monitored
+  - `jobname`: The prometheus job-name
+  - `scrape_interval`: Prometheus scrape interval (optional)
+  - `metrics_path`: Path to metrics (optional)
+- `prometheus_sd_targets`: Optional list of dictionaries of additional targets:
   - `groupname`: The name of the configuration target file, used to name a configuration file so must be unique
   - `group`: A list of Ansible groups (optional)
   - `hosts`: A list of hosts (optional)
   - `port`: The port to be monitored
   - `jobname`: The prometheus job-name
-
   This is intended to be an example.
   In practice these configuration files could be dynamically generated outside this role, prometheus will automatically reload them.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ prometheus_static_targets:
 
 prometheus_targets: []
 
+prometheus_sd_targets: []
+
 # https://github.com/prometheus/alertmanager#example
 # When a new group of alerts is created by an incoming alert, wait at
 # least 'group_wait' to send the initial notification.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,22 +60,13 @@
     name: docker-python
     state: present
 
-- name: pull an image
-  become: yes
-  docker_image:
-    name: "{{ item }}"
-  with_items:
-  - prom/alertmanager:v0.6.2
-  - prom/blackbox-exporter:v0.5.0
-  - prom/prometheus:v1.7.0
-
 - name: prometheus | docker alertmanager
   become: yes
   docker_container:
     command: >
       -config.file=/etc/prometheus/alertmanager.yml
       -storage.path=/alertmanager
-    image: prom/alertmanager
+    image: prom/alertmanager:v0.8.0
     name: alertmanager
     published_ports:
     - 9093:9093
@@ -90,8 +81,8 @@
 - name: prometheus | docker blackbox-exporter
   become: yes
   docker_container:
-    command: "-config.file=/etc/prometheus/blackbox-exporter.yml"
-    image: prom/blackbox-exporter
+    command: "--config.file=/etc/prometheus/blackbox-exporter.yml"
+    image: prom/blackbox-exporter:v0.8.1
     name: blackbox-exporter
     published_ports:
     - 9115:9115
@@ -111,7 +102,7 @@
       -web.console.libraries=/usr/share/prometheus/console_libraries
       -web.console.templates=/usr/share/prometheus/consoles
       -alertmanager.url=http://alertmanager:9093
-    image: prom/prometheus
+    image: prom/prometheus:v1.7.1
     links:
     - alertmanager:alertmanager
     - blackbox-exporter:blackbox-exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
     force: yes
     src: file_sd_config-template-yml.j2
   with_items:
-    - "{{ prometheus_targets }}"
+    - "{{ prometheus_sd_targets }}"
 
 # Docker containers
 

--- a/templates/etc-prometheus-prometheus-yml.j2
+++ b/templates/etc-prometheus-prometheus-yml.j2
@@ -89,6 +89,29 @@ scrape_configs:
       - target_label: __address__
         replacement: blackbox-exporter:9115
 
+{% for item in prometheus_targets %}
+
+  - job_name: {{ item.jobname }}
+    scrape_interval: {{ item.scrape_interval | default('15s') }}
+    metrics_path: {{ item.metrics_path | default('/metrics') }}
+    static_configs:
+{%   if 'hosts' in item %}
+    - targets: {{ item.hosts | json_query("map(&join(':', [@, '" + (item.port | string) + "']), @)") | to_json }}
+{%   endif %}
+{%   for group in item.groups | default([]) %}
+{%     for host in groups[group] | default([]) | sort %}
+    - targets:
+      - {{
+          (hostvars[host][
+            'ansible_' + (item.iface | default('eth0'))].ipv4.address +
+            ":" + (item.port | string)) | to_json
+        }}
+      labels:
+        instance: {{ hostvars[host].ansible_hostname }}
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+
   # Other target files
   # (reloaded automatically, can be used for dynamic updates)
   - job_name: additional targets


### PR DESCRIPTION
Adds `metrics_path` as an option for scraping targets

This involves moving the `prometheus_targets` into the main configuration file `/etc/prometheus/prometheus.yml` instead of separate files `/etc/prometheus/targets/{{ item.groupname }}.yml` since the configuration for files under target doesn't support `metrics_path` as easily. This also add `scrape_interval` as an option.

Functionally this should have no change for existing configurations, however it is breaking since this does not delete the old configuration files.

This also reverts to using ome-ansible-molecule-dependencies in travis

Tag: `0.2.0`