### PR TITLE
Update components, add example of custom alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Parameters
 - `prometheus_blackboxexporter_port`: External Blackbox-exporter port, set to `0` to disable, default `9115`
 - `prometheus_additional_command_args`: Additional command line arguments for prometheus
 - `prometheus_alertmanager_additional_command_args`: Additional command line arguments for alertmanager
+- `prometheus_additional_rules_template`: Template with additional alert rules.
+  See https://awesome-prometheus-alerts.grep.to/rules for some ideas but note the labels may be different.
+
 
 - `prometheus_docker_network`: Docker network for prometheus Docker applications, default `prometheus`
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ If this fails try creating a [manual alert](https://github.com/prometheus/alertm
 
     curl -H "Content-Type: application/json" -d '[{"labels":{"alertname":"TestAlert1"}}]' localhost:9093/api/v1/alerts
 
+The molecule test also includes a disk space alert configuration.
+To test this fill up at least 90% of the `/run` partition:
+
+    molecule login
+    dd if=/dev/zero of=/run/fill.space bs=1M count=...
+
+Wait a few minutes and you should see a disk space warning.
+
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,12 @@ prometheus_targets: []
 
 prometheus_sd_targets: []
 
+# Template with additional alert rules
+# Defaults to an empty placeholder file as this is easier than conditionally
+# deleting a file if it's not needed
+prometheus_additional_rules_template:
+  "etc-prometheus-additional-alert-rules-yml.j2"
+
 # https://github.com/prometheus/alertmanager#example
 # When a new group of alerts is created by an incoming alert, wait at
 # least 'group_wait' to send the initial notification.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,6 @@ prometheus_docker_network: prometheus
 ######################################################################
 
 # Prometheus component versions
-prometheus_version: 2.2.1
-prometheus_alertmanager_version: 0.14.0
-prometheus_blackboxexporter_version: 0.12.0
+prometheus_version: 2.20.1
+prometheus_alertmanager_version: 0.21.0
+prometheus_blackboxexporter_version: 0.17.0

--- a/molecule/default/example-rules-yml.j2
+++ b/molecule/default/example-rules-yml.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+# See https://awesome-prometheus-alerts.grep.to/rules
+# for useful rules but note the labels may be different
+# Remember this is a Jinja2 template processed by Ansible
+
+{% raw %}
+
+groups:
+
+- name: 10% disk space remaining
+  rules:
+
+  - alert: HostOutOfDiskSpace
+    expr: (node_filesystem_avail_bytes{mountpoint="/run"} * 100) / node_filesystem_size_bytes{mountpoint="/run"} < 10
+    # for: 5m
+    for: 10s
+    labels:
+      severity: warn
+    annotations:
+      summary: "Host out of disk space (instance {{ $labels.instance }})"
+      description: "Disk is almost full (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+{% endraw -%}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,6 +14,8 @@ platforms:
     command: /sbin/init
     groups:
       - docker-hosts
+      # published_ports:
+      #   - "0.0.0.0:9090:9090/tcp"
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -34,14 +34,23 @@
         - idr.openmicroscopy.org:873
       prometheus_targets:
         - hosts: ["{{ hostname_ip.stdout }}"]
+          port: 9100
+          jobname: nodes
+          scrape_interval: 5s
+        - hosts: ["{{ hostname_ip.stdout }}"]
           port: 54321
           jobname: fake-metrics
           scrape_interval: 5s
           metrics_path: /alternative-metrics
+      prometheus_additional_rules_template: example-rules-yml.j2
 
 
-# Setup some fake metrics using nginx
+# Setup some real and fake metrics using nginx
 - hosts: all
+
+  roles:
+    - role: ome.prometheus_node
+
   tasks:
 
     - name: create fake metric file

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,2 +1,4 @@
 ---
 - src: ome.docker
+
+- src: ome.prometheus_node

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,14 @@
     src: etc-prometheus-default-alert-rules-yml.j2
   register: prometheus_alert_rules
 
+- name: prometheus | prometheus additional alert rules
+  become: true
+  template:
+    dest: /etc/prometheus/rules/additional-alert.rules.yml
+    force: true
+    src: "{{ prometheus_additional_rules_template }}"
+  register: prometheus_alert_rules_additional
+
 - name: prometheus | alertmanager configuration file
   become: true
   template:
@@ -125,7 +133,9 @@
          ':9090'], []) }}
     # read_only: True
     recreate: >-
-      {{ prometheus_configuration.changed or prometheus_alert_rules.changed }}
+      {{ prometheus_configuration.changed or
+         prometheus_alert_rules.changed or
+         prometheus_alert_rules_additional.changed }}
     restart_policy: always
     state: started
     volumes:

--- a/templates/etc-prometheus-additional-alert-rules-yml.j2
+++ b/templates/etc-prometheus-additional-alert-rules-yml.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+# See https://awesome-prometheus-alerts.grep.to/rules
+# for useful rules but note the labels may be different


### PR DESCRIPTION
Includes instructions for testing disk-space alerts (and by extension other alerts) in molecule.

Tag: `0.4.0`. I'm not sure if there are actually any breaking changes here, but it seems long enough since the last major release