### PR TITLE
Update to allow running outside a cloud

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -34,5 +34,14 @@ jobs:
         with:
           scenario: ${{ matrix.scenario }}
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  build:
+    name: Galaxy
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: galaxy
+        uses: ome/action-ansible-galaxy-publish@main
+        with:
+          galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Parameters
 
   This is intended to be an example.
   In practice these configuration files could be dynamically generated outside this role, prometheus will automatically reload them.
-- `prometheus_custom_targets`: Optional list of dictionaries of additional targets with custom arguments, use this if you need to pass custom arguments that aren't supported by the previous two parameters. Each item will be used verbatim, no processing is done
+- `prometheus_custom_targets`: Optional list of dictionaries of additional targets with custom arguments, use this if you need to pass custom arguments that aren't supported by the previous two parameters.
+  Each item is a [`<scrape_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) that will be copied unchanged into the configuration.
 - `prometheus_port`: External Prometheus port, set to `0` to disable, default `9090`
 - `prometheus_alertmanager_port`: External Alertmanager port, set to `0` to disable, default `9093`
 - `prometheus_blackboxexporter_port`: External Blackbox-exporter port, set to `0` to disable, default `9115`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Parameters
 
 
 - `prometheus_docker_network`: Docker network for prometheus Docker applications, default `prometheus`
+- `prometheus_docker_user`: User ID that prometheus should run as, default is the container default
+- `prometheus_docker_data_volume`: Docker volume or host path for Prometheus data, default is a docker volume called `prometheus-data`. If this is a host path it must be writeable by `prometheus_docker_user`.
 
 
 Example playbook

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Parameters
 - `prometheus_docker_data_volume`: Docker volume or host path for Prometheus data, default is a docker volume called `prometheus-data`. If this is a host path it must be writeable by `prometheus_docker_user`.
 
 
+Outputs
+-------
+This role sets the following variables which can be used in other tasks:
+- `prometheus_internal_ip`: Internal IP of the Prometheus container
+- `prometheus_blackboxexporter_internal_ip`: Internal IP of the Blackbox exporter container
+- `prometheus_alertmanager_internal_ip`: Internal IP of the AlertManager container
+
+These are intended for use when you don't want to expose the container ports using standard Docker port-forwarding (set `prometheus_*port: 0`).
+
+
 Example playbook
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Parameters
   - `hosts`: A list of hosts (optional)
   - `port`: The port to be monitored
   - `jobname`: The prometheus job-name
+
   This is intended to be an example.
   In practice these configuration files could be dynamically generated outside this role, prometheus will automatically reload them.
- External ports, set to 0 to disable
+- `prometheus_custom_targets`: Optional list of dictionaries of additional targets with custom arguments, use this if you need to pass custom arguments that aren't supported by the previous two parameters. Each item will be used verbatim, no processing is done
 - `prometheus_port`: External Prometheus port, set to `0` to disable, default `9090`
 - `prometheus_alertmanager_port`: External Alertmanager port, set to `0` to disable, default `9093`
 - `prometheus_blackboxexporter_port`: External Blackbox-exporter port, set to `0` to disable, default `9115`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ prometheus_targets: []
 
 prometheus_sd_targets: []
 
+prometheus_custom_targets: []
+
 # Template with additional alert rules
 # Defaults to an empty placeholder file as this is easier than conditionally
 # deleting a file if it's not needed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,12 @@ prometheus_alertmanager_additional_command_args: ''
 # Docker network for prometheus components
 prometheus_docker_network: prometheus
 
+# User ID that prometheus should run as, default is the container default
+# prometheus_docker_user:
+
+# Volume for prometheus data
+prometheus_docker_data_volume: prometheus-data
+
 
 ######################################################################
 # Expert users only!

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,6 +95,7 @@
     volumes:
       - /etc/prometheus/alertmanager.yml:/etc/prometheus/alertmanager.yml:ro
       - alertmanager-data:/alertmanager
+  register: _alertmanager_container
 
 - name: prometheus | docker blackbox-exporter
   become: true
@@ -114,6 +115,7 @@
     state: started
     volumes:
       - /etc/prometheus/blackbox-exporter.yml:/etc/prometheus/blackbox-exporter.yml:ro
+  register: _blackboxexporter_container
 
 - name: prometheus | docker prometheus
   become: true
@@ -146,6 +148,7 @@
       - /etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - /etc/prometheus/targets/:/etc/prometheus/targets/:ro
       - "{{ prometheus_docker_data_volume }}:/prometheus"
+  register: _prometheus_container
 
 # In certain situations if a manual change means Prometheus in Docker
 # auto restarted but a host mounted file wasn't present it'll be auto
@@ -167,3 +170,27 @@
   # (there's nothing senstive in there)
   # The asserts will be in the same order as the previous task
   no_log: true
+
+- name: prometheus | return container IPs
+  set_fact:
+    # These default() are needed because the "X.container" property is the
+    # recommended way to access this information but Ansible 2.6 only has the
+    # deprecated "X.ansible_facts.docker_container" property
+    prometheus_internal_ip: >-
+      {{
+        (_prometheus_container.container | default(
+           _prometheus_container.ansible_facts.docker_container)
+        ).NetworkSettings.IPAddress
+      }}
+    prometheus_blackboxexporter_internal_ip: >-
+      {{
+        (_blackboxexporter_container.container | default(
+           _blackboxexporter_container.ansible_facts.docker_container)
+        ).NetworkSettings.IPAddress
+      }}
+    prometheus_alertmanager_internal_ip: >-
+      {{
+        (_alertmanager_container.container | default(
+           _alertmanager_container.ansible_facts.docker_container)
+        ).NetworkSettings.IPAddress
+      }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,13 +138,14 @@
          prometheus_alert_rules_additional.changed }}
     restart_policy: always
     state: started
+    user: "{{ prometheus_docker_user | default(omit) }}"
     volumes:
       # We could mount /etc/prometheus instead but the Docker image contains
       # additional (optional) files
       - /etc/prometheus/rules/:/etc/prometheus/rules/:ro
       - /etc/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - /etc/prometheus/targets/:/etc/prometheus/targets/:ro
-      - prometheus-data:/prometheus
+      - "{{ prometheus_docker_data_volume }}:/prometheus"
 
 # In certain situations if a manual change means Prometheus in Docker
 # auto restarted but a host mounted file wasn't present it'll be auto

--- a/templates/etc-prometheus-prometheus-yml.j2
+++ b/templates/etc-prometheus-prometheus-yml.j2
@@ -129,3 +129,8 @@ scrape_configs:
     file_sd_configs:
     - files:
       - "/etc/prometheus/targets/*.yml"
+
+  # Targets requiring custom options
+{% for item in prometheus_custom_targets %}
+  - {{ item | to_json }}
+{% endfor %}


### PR DESCRIPTION
Previously this role was used in the IDR inside a segregated network where all servers are standardised. We now want to run this on a shared VLAN where the servers aren't standard, and where we'd ideally not expose the default docker ports. This requires:
- Additional custom configuration of targets to be scraped
- Ability to proxy a container directly using the internal Docker IP instead of using Docker port-forwarding
- Support for externally managed Docker host volumes

Tag: `0.5.0` new feature

Requires
- [x] https://github.com/manics/action-ansible-galaxy-publish to be transferred to `ome`
- [ ] `GALAXY_API_KEY` secret